### PR TITLE
2024 updates to AHP

### DIFF
--- a/ahp.md
+++ b/ahp.md
@@ -1,16 +1,16 @@
-# HAI Global Anti-Harassment Policy
-This policy is intended for all HAI workshops and events (in person and online), not the events that take place outside of formal HAI functions. It applies to all participants and volunteers. It is your responsibility to be familiar with this policy and to read all pre-workshop, on-line training or event rules and policies prior to attending any HAI event.
+# HAI Global Anti-Harassment and Inappropriate Sexual Behavior Policy
+HAI Global (HAI) strives to create and maintain an environment in which people are treated in accordance with our values: Respect, Kindness, Integrity, Curiosity, and Humility. The workshop environment should be characterized by consent and the absence of intimidation, oppression and exploitation. HAI Global will not tolerate unlawful harassment of any kind. HAI Global strongly encourages anyone who feels they have experienced a violation, harassment, and/or breach of consent at a HAI event to take immediate action.
 
-HAI Global (HAI) strives to create and maintain an environment in which people are treated in accordance with our values: Respect, Kindness, Integrity, Curiosity, and Humility. The workshop environment should be characterized by consent and the absence of intimidation, oppression and exploitation. HAI Global prohibits harassment of any kind, including sexual harassment, and will take appropriate and immediate action in response to complaints or knowledge of violations of this policy. HAI Global strongly encourages anyone who has experienced a violation, harassment, and/or breach of consent at a HAI event, or feels they may have, to take immediate action.
+If the person is willing and able, they are encouraged to raise the issue with the other person(s) directly involved, with a view to resolving the issue. If possible, the person should identify the offensive behavior, explain that the behavior is unwelcome and offensive and ask that the behavior stop. This can be done with the support of a Facilitator, Producer, or other qualified HAI event leader. HAI is a strong advocate for consent, and has published our HAI Standards for Consent.
 
-If the person is willing and able, they are encouraged to raise the issue with the other person(s) directly involved, with a view to resolving the issue. If possible, the person should identify the offensive behavior, explain that the behavior is unwelcome and offensive, and ask that the behavior stop. This can be done with the support of a Facilitator, Producer, or other qualified HAI event leader. HAI is a strong advocate for consent, and has published our HAI Standards for Consent.
+All BOD, Staff, volunteers and participants are covered by and must comply with this policy and take appropriate measures to ensure that prohibited conduct does not occur. Appropriate action will be taken with any volunteer or participant who violates this policy. Based on the seriousness of the offense, appropriate action may include verbal or written documentation, suspension, removal from the volunteer program or permanent removal from attending HAI events and workshops. See participation agreements (version 1, version 2- clothing optional event version, online version).
 
-All volunteers and participants are covered by and must comply with this policy and take appropriate measures to ensure that prohibited conduct does not occur. Appropriate action will be taken with any volunteer or participant who violates this policy. Facilitators, volunteers and people in authority at HAI who knowingly allow or tolerate harassment or inappropriate behavior, including the failure to immediately report it to the Safety & Consent (S&C) Office, are in violation of this policy. Based on the seriousness of the offense, appropriate action may include verbal or written documentation, suspension, removal from the volunteer program or permanent removal from attending HAI events and workshops. See participation agreements (In-Person Clothing-Mandatory; In-Person Clothing-Optional; Online Workshops).
+Facilitators, volunteers and all leadership at HAI who knowingly allow or tolerate harassment or inappropriate behavior, including the failure to immediately report it to the S&C Office, are in violation of this policy and subject to appropriate action up to and including removal from HAI.
 
-Courteous, mutually respectful, pleasant, non-coercive interactions between participants, volunteers and employees that are appropriate in workshops and HAI events and acceptable to and welcomed by all parties are not considered to be sexual harassment. Asking permission to touch one another is a standard practice at HAI. Mutual Consent is essential in all situations. If you are unsure, stop what you are doing and ask again.
+Courteous, mutually respectful, pleasant, noncoercive interactions between participants, including volunteers that are appropriate in workshops and HAI events and acceptable to and welcomed by both parties are not considered to be sexual harassment. Asking permission to touch one another is a standard practice at HAI. Mutual Consent is essential in all situations. If you are unsure, stop what you are doing and ask again.
 
 ## Harassment
-For purposes of this policy, harassment is any verbal or physical conduct which may threaten, intimidate or coerce a participant or volunteer or any person working for or on behalf of HAI Global Programs.
+This policy is intended for all HAI workshops and events (in person and online), not the events that take place outside of formal HAI functions. HAI Global prohibits harassment of any kind, including sexual harassment, and will take appropriate and immediate action in response to complaints or knowledge of violations of this policy. For purposes of this policy, harassment is any verbal or physical conduct which may threaten, intimidate or coerce a participant or volunteer or any person working for or on behalf of HAI Global Programs.
 
 The following examples of harassment are intended to be guidelines and are not exclusive when determining whether there has been a violation of this policy:
 
@@ -18,37 +18,43 @@ The following examples of harassment are intended to be guidelines and are not e
 
 * Nonverbal harassment includes distribution, display or discussion of any written or graphic material that ridicules, denigrates, insults, belittles or shows hostility, aversion or disrespect toward an individual or group because of national origin, race, color, religion, age, gender, sexual orientation, pregnancy, appearance, disability, sexual identity, marital status or other protected status.
 
+* Organizational harassment toward HAI global includes actions such as coercion, embezzlement, financial and reputational attacks, and harassment and bullying of staff and leadership.
+
 Inappropriate sexual behavior may take different forms. The following examples of these behaviors are intended to be guidelines and are not exclusive when determining whether there has been a violation of this policy:
 
 * Nonverbal sexual harassment includes the distribution, display or discussion of inappropriate written or graphic material, including calendars, posters and cartoons that are sexually suggestive or show hostility toward an individual or group because of sex; suggestive or insulting sounds; leering; staring; whistling; obscene gestures; content in letters, notes, facsimiles, e-mails, photos, text messages, tweets and Internet postings; or other forms of communication that are sexual in nature and offensive.
 
-* Physical sexual harassment includes unwelcome, unwanted physical contact, including touching, tickling, pinching, patting, brushing up against, hugging, cornering, kissing, fondling, and forced sexual intercourse or assault. It also includes nudity in inappropriate situations such as online and clothing-on events. Nudity at clothing optional events is not in itself sexual harassment.
+* Physical sexual harassment includes unwelcome, unwanted physical contact, including touching, tickling, pinching, patting, brushing up against, hugging, cornering, kissing, fondling, and forced sexual intercourse or assault.
 
 Any person who is found to have violated this aspect of the policy will be subject to discipline up to and including removal from HAI.
 
 ## Filing a Report
-A report of a violation, harassment, and/or breach of consent can be initiated by any member of the HAI community by completing an online Incident Report Form. They may also report the behavior by contacting a HAI Facilitator, Producer, or Executive Director. It is critical that each incident be reported to the S&C Office by filing an incident report; just notifying someone isn’t enough. Any breach of consent, violation, and/or harassment report will be treated seriously and promptly. Such reports will be treated as confidential to the extent possible. HAI discloses information strictly on a need-to-know basis.
+A report of a violation, harassment, and/or breach of consent can be initiated by any member of the HAI community by completing an online Incident Report Form. They may also report the behavior by contacting a HAI Facilitator, Producer, or Executive Director. Any breach of consent, violation, and/or harassment report will be treated seriously and promptly. Such reports will be treated as confidential to the extent possible. HAI discloses information strictly on a need-to-know basis.
 
-The person harmed should be prepared to provide details such as what happened; who it happened with; when it happened; where it happened; how often and who else was present (if applicable). Reports should be made as soon as possible, unless there are circumstances that prevent the person harmed from doing so. Every effort will be made to resolve reports within 60 days or in accordance with the desires and needs of the person harmed.
+The person harmed should be prepared to provide details such as what happened; when it happened; where it happened; how often and who else was present (if applicable). Reports should be made as soon as possible, unless there are circumstances that prevent the person harmed from doing so. Every effort will be made to resolve reports within 60 days or in accordance with the desires and needs of the person harmed.
 
 ## Reviewing an Incident Report
-A review of the reported incident will be conducted. A Safety and Consent Officer will interview the person who made the complaint (complainant), the person the complaint was made against (respondent), and any witnesses that have been identified. The reviewer will document the outcome in a tracking system that will include a description of the allegations, the response of the respondent, a summary of information learned from witnesses (if applicable), and a recommendation about whether, on a balance of probabilities, a breach of consent, violation, and/or harassment did occur. These reports are not shared outside of HAI.
+A review of the reported incident will be conducted. The reviewer will interview the person who made the complaint, the person the complaint was made against and any witnesses that have been identified. The reviewer will prepare a report that will include a description of the allegations, the response of the person the complaint was made against, a summary of information learned from witnesses (if applicable), and a recommendation about whether, on a balance of probabilities, a breach of consent, violation, and/or harassment did occur.
 
 ## Open-Investigation Policy
-When HAI has an open investigation, the respondent (subject) is no longer able to participate or attend workshops, online events or groups, or any other HAI functions during our information gathering time and until a resolution is determined. There may be situations where it’s appropriate for both the complainant and the respondent to be removed pending investigation. The Safety and Consent Office has the authority to make these decisions.
+When HAI has an open investigation, the respondent (subject) is no longer able to participate or attend workshops, online events or groups, or any other HAI functions during our information gathering time and until a resolution is determined. There may be situations where it’s appropriate for both the complainant and the respondent to be removed pending investigation. The Safety and Consent Council has the authority to make these decisions at its sole discretion.
 
 ## Mediation
 Wherever appropriate and possible, the parties to the incident report will be offered mediation. Mediation is voluntary and confidential, and will only be shared within the organization on a need-to-know basis. It is intended to assist the parties to arrive at a mutually acceptable resolution to the complaint. The mediator will be a person agreed upon by both parties. Each party to the complaint can be accompanied and assisted during mediation sessions by a person of their choosing.
 
+## Safety & Consent Review of Incident Report
+A review of the reported incident will be conducted by the Safety and Consent Office. The reviewer will interview the person who made the complaint, the person the complaint was made against and any witnesses that have been identified. The reviewer will prepare a report that will include a description of the allegations, the response of the person the complaint was made against (respondent), a summary of information learned from witnesses (if applicable), and a recommendation about whether, on a balance of probabilities, a breach of consent, violation, and/or harassment did occur. This report will be submitted to a small executive team that is monitoring all complaints. These reports are not shared outside of HAI.
+
 ## Organizational Responses
-## Remedies for the complainant may include:
-* The option to speak with the respondent and to convey the impact of their actions; this can be done with support of somebody of the complainant’s choice, if desired.
+Remedies for the person who felt harmed may include:
 
-* An acknowledgement of the impact on the complainant by the respondent.
+* The option to speak with the person found to have engaged in the harm and to convey the impact of their actions; this can be done with support of somebody of the person’s choice, if desired.
 
-* An oral or written apology from the respondent.
+* An acknowledgement of the impact on the person harmed by the person who harmed them.
 
-* Hearing a commitment from the respondent that the behavior will not be repeated.
+* An oral or written apology from the person.
+
+* Hearing a commitment from the person that the behavior will not be repeated.
 
 Corrective action for the person found to have harmed may include:
 
@@ -62,7 +68,7 @@ Corrective action for the person found to have harmed may include:
 
 * Restriction on attendance at HAI events
 
-* Conditions or restriction on their Team member status or removal from Team (if applicable)
+* Conditions or restriction on their team member status (if applicable)
 
 * Removal from HAI
 
@@ -72,13 +78,22 @@ All complaints and investigations are treated confidentially to the extent possi
 ## Volunteer Agreements, Signed
 All volunteers will be required to sign a copy of their agreements once a year while an active volunteer. This will include the Team Agreements that are in place that each volunteer agrees to when they are accepted as a team member. The volunteer will follow the agreements as they are written.
 
-## Final Decisions by S&C Council
-Once a decision has been made by the S&C Council, the decision is final. Egregious cases result in removal from HAI, while some lesser violations may include a break from HAI. Removal from HAI is rare, however, when the result is removal, there is no second chance or “path back to HAI.”
+## Final Decisions by S&C
+Once a decision has been made by the S&C Officer, the decision is final. Egregious cases result in removal from HAI, while some lesser violations may include a break from HAI. When the result is removal, there is no second chance or “path back to HAI.”
 
 ## Leadership Role
-HAI Leadership, including our Producers, Facilitators, FITs, Board Members, Staff, and key volunteers, will be accountable to roll out/enforce the actions of the S&C Office.
+Leadership including Producers, Facilitators, FITS, Board Members, Staff, and key volunteers will be accountable to support the actions of the S&C Office.
 
-If leadership is approached by anyone regarding a decision, they are to refer that person back to the S&C Office. This will happen even if the leader holds a difference of opinion of that of the investigator.
+If leadership is approached by anyone regarding a decision, refer them back to the S&C Office. This will happen even if the leader holds a difference of opinion of that of the investigator. If new information is presented S&C may reconsider. If an escalation is deemed necessary, S&C will refer the matter to the Executive Director and Legal Counsel.(NOTE: The ED is informed of any S&C issues beyond simple participant mediation needs). The next step of escalation is to the full Safety and Consent Council comprising Board, HR, Legal and Executive Positions. Any incident that involves a Facilitator immediately gets escalated to the Executive Director.
+
+## Leadership Role
+Leadership including Producers, Facilitators, FITS, Board Members, Staff, and key volunteers will be accountable to support the actions of the S&C Office.
+
+If leadership is approached by anyone regarding a decision, refer them back to the S&C Office. This will happen even if the leader holds a difference of opinion of that of the investigator. If new information is presented S&C may reconsider. If an escalation is deemed necessary, S&C will refer the matter to the Executive Director and Legal Counsel. (NOTE: The ED is informed of any S&C issues beyond simple participant mediation needs). The next step of escalation is to the full Safety and Consent Council comprising Board, HR, Legal and Executive Positions. Any incident that involves a Facilitator immediately gets escalated to the Executive Director.
 
 ## Board of Director Reporting
-The board has access to a report, updated concurrently with the unfolding of each case, which provides an overview of all cases to date without revealing the identities of anyone involved in any case.
+The BOD receives quarterly reports updating stats and general status regarding any S&C issues and anything escalating into the S&C full Council.
+
+UPDATE in 2024: Change was made to include Staff.
+
+Adopted 2020, updated 2024


### PR DESCRIPTION
This is my work in progress tally of all the sweeping changes that were made in this update, by whomever updated it.
To see the raw changes instead, see the full set under the "Files Changed" tab above - left = 2021, right = 2024 version.

## ± Changes
* Document title / scope now also includes `and Inappropriate Sexual Behavior`
* "HAI Global `prohibits` → `will not tolerate unlawful` harassment"
* "`A Safety and Consent Officer` → `The reviewer` will interview the incident reporter" under `Reviewing an Incident Report`
* "The reviewer will `document the outcome in a tracking system` → `prepare a report`" (only made available to the board at some point the ensuing quarter, so they cannot oversee or intervene, as previously, where it was continuously available to them in real time, enabling board oversight) under `Reviewing an Incident Report`

## + Adds
* A duplicate and identical `Leadership Role ` section, right after the existing one
* `UPDATE in 2024: Change was made to include Staff.` added as the sole summary of all here listed document changes
* "All `BOD, Staff,` volunteers and participants are covered by and must volunteers and participants are covered by and must comply with this policy and take appropriate measures to comply with this policy and take appropriate measures to ensure that prohibited conduct does not occur." added to this sentence, as noted in above point
* `Adopted 2020, updated 2024` added as a final annotation
* `Organizational harassment toward HAI global includes actions such as coercion, embezzlement, financial and
reputational attacks, and harassment and bullying of staff and leadership.` bullet point added to `Harassment` section
* "Facilitators, volunteers and people in authority at HAI who knowingly allow or tolerate harassment or inappropriate behavior, including the failure to immediately report it to the Safety & Consent (S&C) Office, are in violation of this policy ` and subject to appropriate action up to and including removal from HAI.`." provision near top of document, moved down past the links, while adding the noted sentence tail.

## - Removes
* `including sexual harassment, and will take appropriate and immediate action in response to complaints or knowledge of violations of this policy` duplication (from what HAI prohibits/won't tolerate), already mentioned later
* `It also includes nudity in inappropriate situations such as online and clothing-on events. Nudity at clothing optional events is not in itself sexual harassment.` clarification from `Physical sexual harassment` definition
* `It is critical that each incident be reported to the S&C Office by filing an incident report; just notifying someone isn’t enough.` note from `Filing a Report`
* `who it happened with` removed from details to file in incident report
* `These reports are not shared outside of HAI.` from `Reviewing an Incident Report`

## → Move/restructure edits
* Top-of-document first paragraph `This policy is intended for all HAI workshops and events (in person and online), not the events that take place outside of formal HAI functions.`, and
* second-paragraph sentence `HAI Global prohibits harassment of any kind, including sexual harassment, and will take appropriate and immediate action in response to complaints or knowledge of violations of this policy.` moved to top of `Harassment` section, adding `For purposes of this policy, harassment is any verbal or physical conduct which may threaten, intimidate or coerce a participant or volunteer or any person working for or on behalf of HAI Global Programs.`
* removing 2nd+3rd sentences:
  * `It applies to all participants and volunteers.`, and
  * `It is your responsibility to be familiar with this policy and to read all pre-workshop, on-line training or event rules and policies prior to attending any HAI event.`,
* retaining next sentence `HAI Global prohibits harassment of any kind, including sexual harassment, and will take appropriate and immediate action in response to complaints or knowledge of violations of this policy.`, and
* rewrites next sentences:
  * "HAI Global <del>prohibits</del> harassment of any kind<del>, including sexual harassment, and will take appropriate and immediate action in response to complaints or knowledge of violations of this policy</del>. HAI Global strongly encourages anyone who <del>has</del> experienced a violation, harassment, and/or breach of consent at a HAI event, or feels they may have, to take immediate action." to
   * "HAI Global <ins>will not tolerate unlawful</ins> harassment of any kind. HAI Global strongly encourages anyone <ins>who feels they have</ins> experienced a violation, harassment, and/or breach of consent at a HAI event to take immediate action."
